### PR TITLE
fix: display issue of .find-results & shadow dom

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,6 +1,6 @@
 @import 'syntax-variables';
 
-atom-text-editor, :host {
+atom-text-editor, atom-text-editor::shadow, :host {
     background-color: @syntax-background-color;
     color: @syntax-text-color;
 
@@ -40,19 +40,23 @@ atom-text-editor, :host {
         border: 1px solid @syntax-result-marker-color;
     }
 
-    .highlight.current-result .region,
-    .highlight.current-result ~ .highlight.selection .region {
-        //at some point in the future, if/when Atom allows the developer to specify
-        //selected text foreground color, we'll use a brighter background. For now,
-        //we'll use a dark gray so it shows the syntax well but use a bright border.
-        // background: @light-yellow;
-        background: @dark-gray;
-        border: 1px solid @syntax-result-marker-color-selected!important;
-    }
+    .highlight {
+      &.find-result .region,
+      &.current-result .region,
+      &.current-result ~ .highlight.selection .region {
+        z-index: -1;
+      }
 
-    .find-result .region {
-        background: @highlight-blue!important;
-        border: 1px solid @syntax-result-marker-color!important;
+      &.find-result .region {
+        background: @highlight-blue !important;
+        border: 1px solid @syntax-result-marker-color !important;
+      }
+
+      &.current-result .region,
+      &.current-result ~ .highlight.selection .region {
+        background: @light-yellow;
+        border: 1px solid @syntax-result-marker-color-selected !important;
+      }
     }
 
   .gfm {


### PR DESCRIPTION
Hey, there was a display issue with the find results on Atom 1.8.0 (OSX 11.11.5). This should take care of it. Cheers

Before
<img width="300" alt="screen shot 2016-06-15 at 3 42 09 pm" src="https://cloud.githubusercontent.com/assets/1139068/16094883/324c9caa-3310-11e6-984e-6325d8907625.png">

After
<img width="300" alt="screen shot 2016-06-15 at 3 40 25 pm" src="https://cloud.githubusercontent.com/assets/1139068/16094886/35ef48a8-3310-11e6-865b-f9bfb12121fb.png">
